### PR TITLE
changed /upload links to correct /deploy and updated docs

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -11,7 +11,7 @@ Here is a table that would help you to find out the currently available projects
 | Project       | Skills                                       | Repository                                                          | Documentation                               |
 | ------------- | -------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------- |
 | core          | C, C++, Python, Javascript, Typescript, Ruby | [metacall/core](https://github.com/metacall/core)                   | [docs](/docs/docs.md)                       |
-| upload        | Typescript, Javascript                       | [metacall/upload](upload)                                           | [upload](upload.md)                         |
+| upload        | Typescript, Javascript                       | [metacall/deploy](https://github.com/metacall/deploy)               | [deploy](/docs/deploy.md)                         |
 | install       | BASH                                         | [metacall/install](https://github.com/metacall/install)             | [install](/docs/install.md)                 |
 | dlang-port    | D                                            | [metacall/dlang-port](https://github.com/metacall/dlang-port)       | [dlang-port](/docs/dlang-port.md)           |
 | php-port      | PHP                                          | [metacall/php-port](https://github.com/metacall/php-port)           | [php-port](/docs/php-port.md)               |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,4 +1,4 @@
-# upload
+# Deploy
 
 Tool for deploying into MetaCall FaaS platform.
 


### PR DESCRIPTION
# BUG:
In https://core.metacall.io/#/docs/contribute, after clicking on the "metacall/upload" or "upload" link, we are directed to a 404 page. 

# SOLUTION:
I got to know that the project has been changed to "metacall/deploy", so I corrected the related links, renamed the "docs/upload.md" to "docs/deploy.md", then corrected the heading within the .md file. Now both the links work perfectly and redirect to the correct pages.